### PR TITLE
separate fixture code from example code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 *.tfstate.*
 
 # .tfvars files
-*.tfvars
+#*.tfvars

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 module "sample_mod" {
-  source = "github.com/ukslee/tf-module-skeleton.git?ref=master"
+  source = "github.com/ukslee/tf-module-skeleton.git?ref=v0.1.0"
 
   sample_variable = "sample_var"
 }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,19 +1,22 @@
 ---
 driver:
   name: terraform
-  root_module_directory: test/fixtures
-
 provisioner:
   name: terraform
-
 verifier:
   name: terraform
 
 platforms:
   - name: default
-    drivier:
+    driver:
       root_module_directory: test/fixtures/default
+      variable_files:
+        - test/fixtures/default/default.tfvars
 
+suites:
+  - name: default
+    includes:
+      - default
     verifier:
       systems:
         - name: local
@@ -21,6 +24,3 @@ platforms:
           controls:
             - state_file
             - terraform_output
-
-suites:
-  - name: default

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,8 +1,7 @@
 ---
 driver:
   name: terraform
-
-  root_module_directory: examples/complete
+  root_module_directory: test/fixtures
 
 provisioner:
   name: terraform
@@ -11,8 +10,9 @@ verifier:
   name: terraform
 
 platforms:
-  - name: tf_state
+  - name: default
     drivier:
+      root_module_directory: test/fixtures/default
 
     verifier:
       systems:

--- a/test/fixtures/default/README.md
+++ b/test/fixtures/default/README.md
@@ -1,0 +1,20 @@
+# tf-module-skeleton example
+simple example of tf-module-skeletion
+
+## Usage
+```
+module "sample" {
+   source = "github.com/ukslee/tf-module-skeleton.git?ref=master"
+
+   sample_variable = "sample"
+}
+```
+
+## Steps to test run this example
+1. edit `terraform.tfvars` file to specify your credential for test environment
+1. run below commands
+```
+$ terraform init
+$ terraform plan
+$ terraform apply
+```

--- a/test/fixtures/default/default.tfvars
+++ b/test/fixtures/default/default.tfvars
@@ -1,0 +1,2 @@
+aws_region = "us-west-2"
+aws_profile = "default"

--- a/test/fixtures/default/main.tf
+++ b/test/fixtures/default/main.tf
@@ -1,0 +1,5 @@
+module "sample_mod" {
+  source = "../../../"
+
+  sample_variable = "sample_var"
+}

--- a/test/fixtures/default/provider.tf
+++ b/test/fixtures/default/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region              = "${var.aws_region}"
+  profile             = "${var.aws_profile}"
+}

--- a/test/fixtures/default/variables.tf
+++ b/test/fixtures/default/variables.tf
@@ -1,0 +1,7 @@
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "aws_profile" {
+  default = "default"
+}

--- a/test/integration/default/controls/state_file.rb
+++ b/test/integration/default/controls/state_file.rb
@@ -3,6 +3,6 @@ control 'state_file' do
 
   tfstate = command('find $(pwd) -name "terraform.tfstate"').stdout.delete("\n")
   describe json(tfstate).terraform_version do
-    it { should match "/\d+\.\d+\.\d+/" }
+    it { should match(/\d+\.\d+\.\d+/) }
   end
 end

--- a/test/integration/default/controls/state_file.rb
+++ b/test/integration/default/controls/state_file.rb
@@ -1,8 +1,8 @@
-control "state_file" do
-  desc "Verifies that the Terraform state file can be used in InSpec controls"
+control 'state_file' do
+  desc 'Verifies that the Terraform state file can be used in InSpec controls'
 
-  tfstate=command('find $(pwd) -name "terraform.tfstate"').stdout.gsub("\n","")
+  tfstate = command('find $(pwd) -name "terraform.tfstate"').stdout.delete("\n")
   describe json(tfstate).terraform_version do
-    it { should match /\d+\.\d+\.\d+/ }
+    it { should match "/\d+\.\d+\.\d+/" }
   end
 end

--- a/test/integration/default/controls/tf_output.rb
+++ b/test/integration/default/controls/tf_output.rb
@@ -1,10 +1,14 @@
-control "terraform_output" do
-  desc "Verifies that the Terraform state file contains proper output result"
+control 'terraform_output' do
+  desc 'Verifies that the Terraform state file contains proper output result'
 
-  tfstate_json=json(command('find $(pwd) -name "terraform.tfstate"').stdout.gsub("\n",""))
-  sample_mod=tfstate_json.modules.find { |mod| mod["path"]==["root","sample_mod"]}
+  tfstate_json = json(
+    command('find $(pwd) -name "terraform.tfstate"')
+    .stdout.delete("\n")
+  )
+  sample_mod = tfstate_json.modules
+                           .find { |mod| mod['path'] == %w[root sample_mod] }
 
-  describe sample_mod["outputs"]["sample_output"]["value"] do
-    it { should eq 'sample output'}
+  describe sample_mod['outputs']['sample_output']['value'] do
+    it { should eq 'sample output' }
   end
 end

--- a/test/integration/default/controls/tf_output.rb
+++ b/test/integration/default/controls/tf_output.rb
@@ -7,7 +7,6 @@ control 'terraform_output' do
   )
   sample_mod = tfstate_json.modules
                            .find { |mod| mod['path'] == %w[root sample_mod] }
-
   describe sample_mod['outputs']['sample_output']['value'] do
     it { should eq 'sample output' }
   end

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,5 +1,5 @@
 name: default
-title: AWS InSpec Profile
+title: Sample InSpec Profile
 maintainer: ukslee
 copyright: 2019 ukslee
 copyright_email: uks78n@gmail.com


### PR DESCRIPTION
- separate fixture code from example code, because the example code need to use fixed reference but fixture code need to use reference to latest code
- change for supporting multiple testing scenario via multiple .tfvars file